### PR TITLE
Fix behavior when masking undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,10 @@ module.exports = (elements, {
   replacement = '--REDACTED--'
 } = {}) => {
   return value => {
+    if (typeof value === 'undefined') {
+      return value;
+    }
+
     for (const element of elements) {
       const search = new RegExp(`<(${element})>(.+)</(${element})>`, `g${ignoreCase ? 'i' : ''}`);
 

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -4,6 +4,7 @@
  */
 
 const maskXml = require('../index');
+const should = require('should');
 
 /**
  * Test `maskXml`.
@@ -42,6 +43,10 @@ describe('maskXml()', () => {
         <secret>*****</secret>
       </foo>
     `);
+  });
+
+  it('should accept undefined', () => {
+    should.not.exist(maskXml(['foo', 'bar'])(undefined));
   });
 
   it('should mask the given xml string', () => {


### PR DESCRIPTION
When providing an `undefined` parameter to the masking function, a `TypeError` is thrown ("TypeError: Cannot read property 'replace' of undefined"). The changes introduced by this PR will make the function simply return `undefined` if that is the supplied parameter.