### PR TITLE
Skip masking non-strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,10 @@ module.exports = (elements, {
   replacement = '--REDACTED--'
 } = {}) => {
   return value => {
+    if (typeof value !== 'string') {
+      return value;
+    }
+
     for (const element of elements) {
       const search = new RegExp(`<(${element})>(.+)</(${element})>`, `g${ignoreCase ? 'i' : ''}`);
 

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -4,6 +4,7 @@
  */
 
 const maskXml = require('../index');
+const should = require('should');
 
 /**
  * Test `maskXml`.
@@ -42,6 +43,12 @@ describe('maskXml()', () => {
         <secret>*****</secret>
       </foo>
     `);
+  });
+
+  it('should skip masking non-strings', () => {
+    [undefined, { biz: 'baz' }, 42].forEach(nonString => {
+      should(maskXml(['foo'])(nonString)).equal(nonString);
+    });
   });
 
   it('should mask the given xml string', () => {


### PR DESCRIPTION
When providing an `undefined` parameter to the masking function (or any non-string for that matter), a `TypeError` is thrown ("TypeError: Cannot read property 'replace' of undefined"). The changes introduced by this PR will make the function simply return the original parameter when it's not a string.